### PR TITLE
Update writeBundle syntax to rollup v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-brotli",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "Compress your Rollup bundle with Brotli",
   "keywords": [
     "rollup",
@@ -29,7 +29,7 @@
     "chai": "4.2.0",
     "mocha": "^6.2.0",
     "rimraf": "^3.0.0",
-    "rollup": "^1.21.4"
+    "rollup": "^2.0.0"
   },
   "dependencies": {},
   "engines": {

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ export default function brotli(options = {}) {
     generateBundle: buildOpts => {
       _dir = (buildOpts.file && dirname(buildOpts.file)) || buildOpts.dir || ''
     },
-    writeBundle: async bundle => {
+    writeBundle: async (outputOptions, bundle) => {
       const compressCollection = []
       const bundlesToCompress = Object.keys(bundle).filter(file => !isCompressed(bundle[file]))
       const files = [...options.additional, ...bundlesToCompress.map(f => join(_dir, f))]


### PR DESCRIPTION
Added required compatible rollup version as devDependency and
upped the version number to indicate incompatility-changes.

Fixes #7