### PR TITLE
[fix] fix magic bytes comparing only first byte

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ function isCompressed (bundle) {
     let matches = true
     const sourceBytes = bundle.type === 'asset' ? bundle.source : Buffer.from(bundle.code)
     for (let i = 0; i < bytes.length; ++i) {
-      matches = matches && bytes[0] === sourceBytes[0]
+      matches = matches && bytes[i] === sourceBytes[i]
     }
     if (matches) return true
   }


### PR DESCRIPTION
Saw the issue for this and figured I'd submit a PR. However, I think the file extension comparison is good enough. Can you think of a use case where files are compressed as those formats, but with a different extension?

Fixes #11 