### PR TITLE
[fix] isCompressed checks more already-compressed extensions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ const magicBytes = [
 ]
 
 function isCompressed (bundle) {
-  if (/\.(gz|zip|xz|lz2|7z)$/.test(bundle.fileName)) return true
+  if (/\.(gz|zip|xz|lz2|7z|woff|woff2)$/.test(bundle.fileName)) return true
   for (const bytes of magicBytes) {
     let matches = true
     const sourceBytes = bundle.type === 'asset' ? bundle.source : Buffer.from(bundle.code)

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ const magicBytes = [
 ]
 
 function isCompressed (bundle) {
-  if (/\.(gz|zip|xz|lz2|7z|woff|woff2)$/.test(bundle.fileName)) return true
+  if (/\.(gz|zip|xz|lz2|7z|woff|woff2|jpg|jpeg|png|webp)$/.test(bundle.fileName)) return true
   for (const bytes of magicBytes) {
     let matches = true
     const sourceBytes = bundle.type === 'asset' ? bundle.source : Buffer.from(bundle.code)


### PR DESCRIPTION
.woff and .woff2 formats are already compressed, essentially already brotli compressed. Compressing them actually increases file size by 4 bytes in all cases I tested.