### PR TITLE
[fix] writeBundle should use bundle.fileName, not bundle id

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ export default function brotli(options = {}) {
     },
     writeBundle: async (outputOptions, bundle) => {
       const compressCollection = []
-      const bundlesToCompress = Object.keys(bundle).filter(file => !isCompressed(bundle[file]))
+      const bundlesToCompress = Object.keys(bundle).filter(id => !isCompressed(bundle[id])).map(id => bundle[id].fileName)
       const files = [...options.additional, ...bundlesToCompress.map(f => join(_dir, f))]
       for (const file of files) {
         compressCollection.push(brotliCompressFile(file, options.options, options.minSize))


### PR DESCRIPTION
Because you can specify your own bundle ids in rollup, they can be anything. Logic should grab the actual filename from bundle[id].fileName instead of assuming the id is the fileName.