### PR TITLE
[fix] valid configuration for mode/quality options

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,14 @@ rollup({
 ### Configuration
 
 ```js
+import zlib from "zlib";
 brotli({
     options: {
-        mode: 0 // "generic mode"
-        level: 7 // turn down the quality, resulting in a faster compression
-        // ... see all options https://nodejs.org/api/zlib.html#zlib_zlib_createbrotlicompress_options
+        params: {
+            [zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_MODE_GENERIC,
+            [zlib.constants.BROTLI_PARAM_QUALITY]: 7 // turn down the quality, resulting in a faster compression (default is 11)
+        }
+        // ... see all options https://nodejs.org/api/zlib.html#zlib_class_brotlioptions
     },
     additional: [
         //  Manually list more files to compress alongside.
@@ -47,7 +50,7 @@ brotli({
 
 **options**: Brotli compression options
 
-The options available are the [standard options for the `zlib.createBrotliCompress` builtin](https://nodejs.org/api/zlib.html#zlib_class_options).
+The options available are the [standard options for the `zlib.createBrotliCompress` builtin](https://nodejs.org/api/zlib.html#zlib_class_brotlioptions).
 
 **additional**: Compress additional files
 


### PR DESCRIPTION
The existing configuration example for mode and level is incorrect, at least from my tests of checking quality 1 vs 7 vs 11. After some experimenting and reading node zlib docs, it appears they are nested as special constants under options.params. After making this change, I was able to see a change in compressed file size as I modified the quality setting.